### PR TITLE
Microsoft Certification requirement

### DIFF
--- a/Code/EcmaScript.NET/AssemblyInfo.cs
+++ b/Code/EcmaScript.NET/AssemblyInfo.cs
@@ -17,6 +17,8 @@ using System.Security;
 
 [assembly: AssemblyTitle("EcmaScript.NET")]
 [assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyCompany("PureKrome")]
+[assembly: AssemblyProduct("EcmaScript.NET")]
 
 [assembly: AssemblyDescriptionAttribute("Modified version of the EcmaScript.NET assembly.")]
 


### PR DESCRIPTION
Microsoft Certification requires that all referenced DLLs provide a company and product name. Added to assembly to pass this requirement.
