### PR TITLE
fixed "missing name after . operator" error for ES6 Promise .catch()

### DIFF
--- a/Code/EcmaScript.NET/Parser.cs
+++ b/Code/EcmaScript.NET/Parser.cs
@@ -13,6 +13,7 @@
 
 using System;
 using System.Collections;
+using System.Text.RegularExpressions;
 
 using EcmaScript.NET.Collections;
 
@@ -40,6 +41,8 @@ namespace EcmaScript.NET
         internal const int CLEAR_TI_MASK = 0xFFFF;
         internal const int TI_AFTER_EOL = 1 << 16;
         internal const int TI_CHECK_LABEL = 1 << 17; // indicates to check for label
+
+        internal readonly Regex SIMPLE_IDENTIFIER_NAME_PATTERN = new Regex("^[a-zA-Z_][a-zA-Z0-9_]*$", RegexOptions.Compiled);
 
         internal CompilerEnvirons compilerEnv;
         ErrorReporter errorReporter;
@@ -1913,6 +1916,7 @@ namespace EcmaScript.NET
                         {
                             int memberTypeFlags;
                             string s;
+                            Match match;
 
                             consumeToken();
                             decompiler.AddToken(tt);
@@ -1962,7 +1966,8 @@ namespace EcmaScript.NET
 
                                 default:
                                     s = ts.TokenString;
-                                    if (s.Length != 0)
+                                    match = SIMPLE_IDENTIFIER_NAME_PATTERN.Match(s);
+                                    if (match.Success)
                                     {
                                         decompiler.AddName(s);
                                         pn = propertyName(pn, s, memberTypeFlags);

--- a/Code/EcmaScript.NET/Parser.cs
+++ b/Code/EcmaScript.NET/Parser.cs
@@ -1961,7 +1961,14 @@ namespace EcmaScript.NET
 
 
                                 default:
-                                    ReportError("msg.no.name.after.dot");
+                                    s = ts.TokenString;
+                                    if (s.Length != 0)
+                                    {
+                                        decompiler.AddName(s);
+                                        pn = propertyName(pn, s, memberTypeFlags);
+                                        AddWarning("msg.reserved.keyword", s);
+                                    } else
+                                        ReportError("msg.no.name.after.dot");
                                     break;
 
                             }

--- a/Code/EcmaScript.NET/TokenStream.cs
+++ b/Code/EcmaScript.NET/TokenStream.cs
@@ -45,6 +45,14 @@ namespace EcmaScript.NET
             }
 
         }
+
+        internal string TokenString
+        {
+            get
+            {
+                return tokenstr;
+            }
+        }
         internal double Number
         {
             get
@@ -183,6 +191,8 @@ namespace EcmaScript.NET
                         ungetChar(c);
 
                         string str = StringFromBuffer;
+                        this.tokenstr = str;
+
                         if (!containsEscape)
                         {
                             // OPT we shouldn't have to make a string (object!) to
@@ -1844,6 +1854,7 @@ namespace EcmaScript.NET
         // string is found.  Fosters one class of error, but saves lots of
         // code.
         private string str = "";
+        private string tokenstr = "";
         private double dNumber;
 
 


### PR DESCRIPTION
Hi @PureKrome

I've noticed your implementation fails on minifying the recent jQuery version 3.2.1:
"missing name after . operator"

It fails because of jQuery using the reserved Keyword catch without proper escaping...
L3887:  		.catch( function( error ) {

In my opinion a minifier implementation should not complain about ANY structure/syntax problems at all!
A minifier should be able to minify whatever it gets - it's the developers job to give a correct input....

My Patch fixes the Problem adressed above by simply passing any token after dot to the output (even if it's not NAME, MUL or XMLATTR)
I don't know if this actually has any unwanted side effects - for me it works 😋 

Greets pk910